### PR TITLE
Add Vercel deployment setup with Neon database support

### DIFF
--- a/app/api/admin/migrate-neon/route.ts
+++ b/app/api/admin/migrate-neon/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import { neon } from '@neondatabase/serverless';
+
+export async function POST() {
+  try {
+    const sql = neon(process.env.POSTGRES_URL || process.env.DATABASE_URL!);
+    
+    console.log('🗄️ Creating database schema on Neon...');
+
+    // Create badges table
+    await sql`
+      CREATE TABLE IF NOT EXISTS badges (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        slug VARCHAR(100) UNIQUE NOT NULL,
+        name VARCHAR(200) NOT NULL,
+        style_key VARCHAR(50) NOT NULL,
+        prompt TEXT NOT NULL,
+        actual_prompt TEXT,
+        style_template VARCHAR(100),
+        reference_style TEXT,
+        quality_setting VARCHAR(20) DEFAULT 'standard',
+        model_used VARCHAR(50) NOT NULL,
+        seed INTEGER,
+        image_blob_url TEXT NOT NULL,
+        thumb_blob_url TEXT NOT NULL,
+        created_by VARCHAR(100) NOT NULL,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      );
+    `;
+
+    // Create people table
+    await sql`
+      CREATE TABLE IF NOT EXISTS people (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name VARCHAR(200) NOT NULL,
+        handle VARCHAR(100),
+        title VARCHAR(200),
+        avatar_url TEXT,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      );
+    `;
+
+    // Create projects table
+    await sql`
+      CREATE TABLE IF NOT EXISTS projects (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name VARCHAR(200) NOT NULL,
+        short_desc TEXT,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      );
+    `;
+
+    // Create awards table
+    await sql`
+      CREATE TABLE IF NOT EXISTS awards (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        badge_id UUID NOT NULL REFERENCES badges(id) ON DELETE CASCADE,
+        person_id UUID NOT NULL REFERENCES people(id) ON DELETE CASCADE,
+        project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        citation TEXT NOT NULL,
+        public_permalink VARCHAR(20) UNIQUE NOT NULL,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      );
+    `;
+
+    // Create indexes
+    await sql`CREATE INDEX IF NOT EXISTS idx_badges_slug ON badges(slug);`;
+    await sql`CREATE INDEX IF NOT EXISTS idx_awards_permalink ON awards(public_permalink);`;
+    await sql`CREATE INDEX IF NOT EXISTS idx_awards_created_at ON awards(created_at DESC);`;
+
+    console.log('✅ Database schema created successfully on Neon!');
+
+    return NextResponse.json({ 
+      success: true, 
+      message: 'Database schema created successfully on Neon!' 
+    });
+
+  } catch (error) {
+    console.error('❌ Migration failed:', error);
+    return NextResponse.json(
+      { error: 'Migration failed', details: error },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/db-neon.ts
+++ b/lib/db-neon.ts
@@ -1,0 +1,130 @@
+import { neon } from '@neondatabase/serverless';
+import type { Badge, Award, Person, Project } from './types';
+
+const sql = neon(process.env.POSTGRES_URL || process.env.DATABASE_URL!);
+
+export async function getBadgeBySlug(slug: string): Promise<Badge | null> {
+  const rows = await sql`
+    SELECT * FROM badges WHERE slug = ${slug} LIMIT 1
+  `;
+  return rows[0] || null;
+}
+
+export async function getAwardByPermalink(permalink: string): Promise<Award | null> {
+  const rows = await sql`
+    SELECT * FROM awards WHERE public_permalink = ${permalink} LIMIT 1
+  `;
+  return rows[0] || null;
+}
+
+export async function getAwardWithDetails(permalink: string) {
+  const rows = await sql`
+    SELECT 
+      a.*,
+      b.name as badge_name,
+      b.image_blob_url,
+      b.thumb_blob_url,
+      b.style_key,
+      p.name as person_name,
+      p.handle as person_handle,
+      p.title as person_title,
+      p.avatar_url as person_avatar,
+      pr.name as project_name,
+      pr.short_desc as project_desc
+    FROM awards a
+    JOIN badges b ON a.badge_id = b.id
+    JOIN people p ON a.person_id = p.id
+    JOIN projects pr ON a.project_id = pr.id
+    WHERE a.public_permalink = ${permalink}
+    LIMIT 1
+  `;
+  return rows[0] || null;
+}
+
+export async function getAllAwards() {
+  const rows = await sql`
+    SELECT 
+      a.*,
+      b.name as badge_name,
+      b.thumb_blob_url,
+      b.style_key,
+      p.name as person_name,
+      p.handle as person_handle,
+      pr.name as project_name
+    FROM awards a
+    JOIN badges b ON a.badge_id = b.id
+    JOIN people p ON a.person_id = p.id
+    JOIN projects pr ON a.project_id = pr.id
+    ORDER BY a.created_at DESC
+  `;
+  return rows;
+}
+
+export async function createBadge(badge: Omit<Badge, 'id' | 'created_at'>): Promise<Badge> {
+  const rows = await sql`
+    INSERT INTO badges (
+      slug, name, style_key, prompt, actual_prompt, style_template,
+      reference_style, quality_setting, model_used, seed, 
+      image_blob_url, thumb_blob_url, created_by
+    ) VALUES (
+      ${badge.slug}, ${badge.name}, ${badge.style_key}, 
+      ${badge.prompt}, ${badge.actual_prompt}, ${badge.style_template},
+      ${badge.reference_style}, ${badge.quality_setting}, ${badge.model_used}, ${badge.seed}, 
+      ${badge.image_blob_url}, ${badge.thumb_blob_url}, ${badge.created_by}
+    )
+    RETURNING *
+  `;
+  return rows[0];
+}
+
+export async function createPerson(person: Omit<Person, 'id' | 'created_at'>): Promise<Person> {
+  const rows = await sql`
+    INSERT INTO people (name, handle, title, avatar_url) 
+    VALUES (${person.name}, ${person.handle}, ${person.title}, ${person.avatar_url})
+    RETURNING *
+  `;
+  return rows[0];
+}
+
+export async function createProject(project: Omit<Project, 'id' | 'created_at'>): Promise<Project> {
+  const rows = await sql`
+    INSERT INTO projects (name, short_desc) 
+    VALUES (${project.name}, ${project.short_desc})
+    RETURNING *
+  `;
+  return rows[0];
+}
+
+export async function createAward(award: Omit<Award, 'id' | 'created_at'>): Promise<Award> {
+  const rows = await sql`
+    INSERT INTO awards (badge_id, person_id, project_id, citation, public_permalink)
+    VALUES (${award.badge_id}, ${award.person_id}, ${award.project_id}, ${award.citation}, ${award.public_permalink})
+    RETURNING *
+  `;
+  return rows[0];
+}
+
+export async function getAllBadges(): Promise<Badge[]> {
+  const rows = await sql`SELECT * FROM badges ORDER BY created_at DESC`;
+  return rows;
+}
+
+export async function getAllPeople(): Promise<Person[]> {
+  const rows = await sql`SELECT * FROM people ORDER BY name`;
+  return rows;
+}
+
+export async function getAllProjects(): Promise<Project[]> {
+  const rows = await sql`SELECT * FROM projects ORDER BY name`;
+  return rows;
+}
+
+export async function deleteAward(awardId: string): Promise<boolean> {
+  try {
+    const rows = await sql`DELETE FROM awards WHERE id = ${awardId}`;
+    return rows.length > 0;
+  } catch (error) {
+    console.error('Error deleting award:', error);
+    return false;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.0",
+        "@neondatabase/serverless": "^1.0.1",
         "@vercel/blob": "^0.27.0",
         "@vercel/og": "^0.6.0",
         "@vercel/postgres": "^0.10.0",
@@ -759,12 +760,16 @@
       }
     },
     "node_modules/@neondatabase/serverless": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.9.5.tgz",
-      "integrity": "sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.1.tgz",
+      "integrity": "sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA==",
       "license": "MIT",
       "dependencies": {
-        "@types/pg": "8.11.6"
+        "@types/node": "^22.15.30",
+        "@types/pg": "^8.8.0"
+      },
+      "engines": {
+        "node": ">=19.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -1705,6 +1710,15 @@
       },
       "engines": {
         "node": ">=18.14"
+      }
+    },
+    "node_modules/@vercel/postgres/node_modules/@neondatabase/serverless": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.9.5.tgz",
+      "integrity": "sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "8.11.6"
       }
     },
     "node_modules/abort-controller": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "db:add-columns": "node scripts/add-badge-columns.mjs",
     "db:seed": "node scripts/seed.mjs",
     "db:setup": "npm run db:up && sleep 3 && npm run db:migrate:local",
-    "db:migrate:vercel": "node scripts/vercel-migrate.mjs"
+    "db:migrate:vercel": "node scripts/vercel-migrate.mjs",
+    "db:migrate:neon": "node scripts/neon-migrate.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.0",
+    "@neondatabase/serverless": "^1.0.1",
     "@vercel/blob": "^0.27.0",
     "@vercel/og": "^0.6.0",
     "@vercel/postgres": "^0.10.0",

--- a/scripts/neon-migrate.mjs
+++ b/scripts/neon-migrate.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import { neon } from '@neondatabase/serverless';
+import dotenv from 'dotenv';
+
+// Load environment variables
+dotenv.config({ path: '.env.local' });
+dotenv.config({ path: '.env.production' });
+
+const sql = neon(process.env.POSTGRES_URL || process.env.DATABASE_URL);
+
+async function migrate() {
+  try {
+    console.log('🗄️ Creating database schema on Neon...');
+
+    // Create badges table
+    await sql`
+      CREATE TABLE IF NOT EXISTS badges (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        slug VARCHAR(100) UNIQUE NOT NULL,
+        name VARCHAR(200) NOT NULL,
+        style_key VARCHAR(50) NOT NULL,
+        prompt TEXT NOT NULL,
+        actual_prompt TEXT,
+        style_template VARCHAR(100),
+        reference_style TEXT,
+        quality_setting VARCHAR(20) DEFAULT 'standard',
+        model_used VARCHAR(50) NOT NULL,
+        seed INTEGER,
+        image_blob_url TEXT NOT NULL,
+        thumb_blob_url TEXT NOT NULL,
+        created_by VARCHAR(100) NOT NULL,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      );
+    `;
+
+    // Create people table
+    await sql`
+      CREATE TABLE IF NOT EXISTS people (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name VARCHAR(200) NOT NULL,
+        handle VARCHAR(100),
+        title VARCHAR(200),
+        avatar_url TEXT,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      );
+    `;
+
+    // Create projects table
+    await sql`
+      CREATE TABLE IF NOT EXISTS projects (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name VARCHAR(200) NOT NULL,
+        short_desc TEXT,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      );
+    `;
+
+    // Create awards table
+    await sql`
+      CREATE TABLE IF NOT EXISTS awards (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        badge_id UUID NOT NULL REFERENCES badges(id) ON DELETE CASCADE,
+        person_id UUID NOT NULL REFERENCES people(id) ON DELETE CASCADE,
+        project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        citation TEXT NOT NULL,
+        public_permalink VARCHAR(20) UNIQUE NOT NULL,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      );
+    `;
+
+    // Create indexes
+    await sql`CREATE INDEX IF NOT EXISTS idx_badges_slug ON badges(slug);`;
+    await sql`CREATE INDEX IF NOT EXISTS idx_awards_permalink ON awards(public_permalink);`;
+    await sql`CREATE INDEX IF NOT EXISTS idx_awards_created_at ON awards(created_at DESC);`;
+
+    console.log('✅ Database schema created successfully on Neon!');
+
+  } catch (error) {
+    console.error('❌ Migration failed:', error);
+    process.exit(1);
+  }
+}
+
+migrate();


### PR DESCRIPTION
## Summary
- Add Vercel deployment configuration and setup scripts
- Integrate Neon Serverless Postgres database support
- Create database migration scripts for both Vercel Postgres and Neon
- Add API endpoint for database migration via HTTP request

## Changes
- Added `lib/db-neon.ts` with Neon-optimized database functions using tagged template literals
- Created `scripts/neon-migrate.mjs` for CLI-based database migration
- Added `app/api/admin/migrate-neon/route.ts` for HTTP-based migration
- Updated `package.json` with Neon dependency and migration script
- Preserved existing Vercel Postgres support in `scripts/vercel-migrate.mjs`

## Test plan
- [ ] Verify Neon database connection and migration works
- [ ] Test both CLI and API migration endpoints
- [ ] Confirm all existing functionality works with new database layer
- [ ] Deploy to Vercel and verify production setup

🤖 Generated with [Claude Code](https://claude.ai/code)