### PR TITLE
Fix: Use environment-based image storage selection

### DIFF
--- a/app/api/admin/generate-image/route.ts
+++ b/app/api/admin/generate-image/route.ts
@@ -1,10 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { generateBadgeImage } from '@/lib/ai';
-import { processAndStoreBadge, generateSlug } from '@/lib/image-vercel';
 import { createBadge } from '@/lib/db';
 import { combineTemplateWithBrief } from '@/lib/style-templates';
 import { z } from 'zod';
 import type { BadgeStyle, BadgeBrief } from '@/lib/types';
+
+// Conditionally import based on environment
+const imageModule = process.env.NODE_ENV === 'production' || process.env.BLOB_READ_WRITE_TOKEN
+  ? await import('@/lib/image-vercel')
+  : await import('@/lib/image');
+
+const { processAndStoreBadge, generateSlug } = imageModule;
 
 const RequestSchema = z.object({
   name: z.string().min(1).max(100),


### PR DESCRIPTION
Dynamically import image module based on environment:
- Use image-vercel.ts in production or when BLOB_READ_WRITE_TOKEN exists
- Use image.ts (local filesystem) for local development

This fixes both production deployment and local development.

🤖 Generated with [Claude Code](https://claude.ai/code)